### PR TITLE
feat: add ignore time precision option in localization and form

### DIFF
--- a/packages/business/src/locale/lang/en.js
+++ b/packages/business/src/locale/lang/en.js
@@ -1328,5 +1328,8 @@ export default {
   packages_business_auto_fill_join_tooltip_all: '3. If there are no non-null fields, use all fields',
   packages_business_nulls_first: 'NULL Priority Sort',
   packages_business_nulls_first_tip:
-    'When the associated fields contain NULL values, the database defaults to sorting NULL values last, which may cause validation failure. Enabling this option will set NULL values first, but may not use the database index, increasing database load.'
+    'When the associated fields contain NULL values, the database defaults to sorting NULL values last, which may cause validation failure. Enabling this option will set NULL values first, but may not use the database index, increasing database load.',
+  packages_business_ignoreTimePrecision: 'Ignore time precision',
+  packages_business_ignoreTimePrecision_tip:
+    'When enabled, time will be compared up to seconds only, ignoring milliseconds. Useful for syncing high-precision and low-precision time fields.'
 }

--- a/packages/business/src/locale/lang/zh-CN.js
+++ b/packages/business/src/locale/lang/zh-CN.js
@@ -1266,5 +1266,8 @@ export default {
   packages_business_auto_fill_join_tooltip_all: '3. 如无非空字段，则使用全部字段',
   packages_business_nulls_first: 'NULL优先排序',
   packages_business_nulls_first_tip:
-    '关联字段存在NULL值时，数据库默认将NULL排在最后，可能导致校验失败。开启此选项将NULL值排在前面，但可能无法使用数据库索引，增加数据库负载。'
+    '关联字段存在NULL值时，数据库默认将NULL排在最后，可能导致校验失败。开启此选项将NULL值排在前面，但可能无法使用数据库索引，增加数据库负载。',
+  packages_business_ignoreTimePrecision: '忽略时间精度',
+  packages_business_ignoreTimePrecision_tip:
+    '开启此开关后会忽略时间毫秒级的比较，只精确到秒级，适用于高精度时间字段同步低精度时间字段场景。'
 }

--- a/packages/business/src/locale/lang/zh-TW.js
+++ b/packages/business/src/locale/lang/zh-TW.js
@@ -1257,5 +1257,6 @@ export default {
   packages_business_auto_fill_join_tooltip_all: '3. 如無非空字段，則使用全部字段',
   packages_business_nulls_first: 'NULL優先排序',
   packages_business_nulls_first_tip:
-    '關聯字段存在NULL值時，數據庫默認將NULL排在最後，可能導致校驗失敗。開啓此選項將NULL值排在前面，但可能無法使用數據庫索引，增加數據庫負載。'
+    '關聯字段存在NULL值時，數據庫默認將NULL排在最後，可能導致校驗失敗。開啓此選項將NULL值排在前面，但可能無法使用數據庫索引，增加數據庫負載。',
+  packages_business_ignoreTimePrecision: '忽略時間精度'
 }

--- a/packages/business/src/views/verification/Form.vue
+++ b/packages/business/src/views/verification/Form.vue
@@ -251,6 +251,18 @@
                   <ElOption :value="10000" label="10000(rows)"></ElOption>
                 </ElSelect>
               </ElFormItem>
+
+              <ElFormItem v-if="!isCountOrHash" class="form-item">
+                <template #label>
+                  <span>{{ $t('packages_business_ignoreTimePrecision') }}</span>
+                  <el-tooltip effect="dark" placement="top" :content="$t('packages_business_ignoreTimePrecision_tip')">
+                    <i class="el-tooltip el-icon-info" style="color: #909399; font-size: 14px"></i>
+                  </el-tooltip>
+                  <span>:</span>
+                </template>
+                <ElSwitch v-model="form.ignoreTimePrecision"></ElSwitch>
+              </ElFormItem>
+
               <template v-if="form.inspectMethod === 'cdcCount'">
                 <ElFormItem class="setting-item">
                   <label class="item-label">{{ $t('packages_business_verification_create_window_duration') }}</label>
@@ -472,6 +484,9 @@ export default {
   computed: {
     saveDisabled() {
       return this.errorMessageLevel === 'error' || this.autoAddTableLoading || this.loading
+    },
+    isCountOrHash() {
+      return this.form.inspectMethod === 'row_count' || this.form.inspectMethod === 'hash'
     }
   },
   created() {


### PR DESCRIPTION
- Introduced new localization entries for "Ignore time precision" and its tooltip in English, Simplified Chinese, and Traditional Chinese.
- Added a toggle switch in the verification form to enable or disable time precision comparison, enhancing user control over time field synchronization.