### PR TITLE
feat: add thread validation option in form settings

### DIFF
--- a/packages/business/src/locale/lang/en.js
+++ b/packages/business/src/locale/lang/en.js
@@ -1588,5 +1588,8 @@ export default {
     'When the associated fields contain NULL values, the database defaults to sorting NULL values last, which may cause validation failure. Enabling this option will set NULL values first, but may not use the database index, increasing database load.',
   packages_business_ignoreTimePrecision: 'Ignore time precision',
   packages_business_ignoreTimePrecision_tip:
-    'When enabled, time will be compared up to seconds only, ignoring milliseconds. Useful for syncing high-precision and low-precision time fields.'
+    'When enabled, time will be compared up to seconds only, ignoring milliseconds. Useful for syncing high-precision and low-precision time fields.',
+  packages_business_checkTableThreadNum: 'Thread Validation',
+  packages_business_checkTableThreadNum_tip:
+    'Number of threads to use. Default is 10. Can be increased if system resources permit.',
 }

--- a/packages/business/src/locale/lang/zh-CN.js
+++ b/packages/business/src/locale/lang/zh-CN.js
@@ -237,7 +237,7 @@ export default {
   packages_business_dataFlow_selectAll: '全选',
   packages_business_dataFlow_skipError_title: '跳过错误设置',
   packages_business_dataFlow_skipError_tip:
-    '任务上次停止时发生了以下数据相关的错误，请确认这些错误已经被处理。如果希望跳过这些错误，请勾选相应的错误项并点击“跳过错误，启动任务” 。',
+    '任务上次停止时发生了以下数据相关的错误，请确认这些错误已经被处理。如果希望跳过这些错误，请勾选相应的错误项并点击"跳过错误，启动任务" 。',
   packages_business_dataFlow_skipError_attention:
     '注意：若导致错误的数据未被处理，跳过错误可能导致这条数据被丢弃。',
   packages_business_dataFlow_skipError_startJob: '跳过错误，启动任务',
@@ -1414,5 +1414,8 @@ export default {
     '关联字段存在NULL值时，数据库默认将NULL排在最后，可能导致校验失败。开启此选项将NULL值排在前面，但可能无法使用数据库索引，增加数据库负载。',
   packages_business_ignoreTimePrecision: '忽略时间精度',
   packages_business_ignoreTimePrecision_tip:
-    '开启此开关后会忽略时间毫秒级的比较，只精确到秒级，适用于高精度时间字段同步低精度时间字段场景。'
+    '开启此开关后会忽略时间毫秒级的比较，只精确到秒级，适用于高精度时间字段同步低精度时间字段场景。',
+  packages_business_checkTableThreadNum: '校验线程数量',
+  packages_business_checkTableThreadNum_tip:
+    '校验线程数量，在资源充足的情况下可进行调整，默认线程数为 10',
 }

--- a/packages/business/src/locale/lang/zh-TW.js
+++ b/packages/business/src/locale/lang/zh-TW.js
@@ -1401,4 +1401,7 @@ export default {
   packages_business_nulls_first_tip:
     '關聯字段存在NULL值時，數據庫默認將NULL排在最後，可能導致校驗失敗。開啓此選項將NULL值排在前面，但可能無法使用數據庫索引，增加數據庫負載。',
   packages_business_ignoreTimePrecision: '忽略時間精度',
+  packages_business_checkTableThreadNum: '校驗線程數量',
+  packages_business_checkTableThreadNum_tip:
+    '校驗線程數量，在資源充足的情況下可進行調整，默認線程數為 10',
 }

--- a/packages/business/src/views/verification/Form.vue
+++ b/packages/business/src/views/verification/Form.vue
@@ -61,6 +61,7 @@ export default {
         taskMode: 'pipeline',
         errorNotifys: ['SYSTEM', 'EMAIL'],
         inconsistentNotifys: ['SYSTEM', 'EMAIL'],
+        checkTableThreadNum: 10,
         alarmSettings: [
           {
             type: 'INSPECT',
@@ -850,11 +851,30 @@ export default {
                     placement="top"
                     :content="$t('packages_business_ignoreTimePrecision_tip')"
                   >
-                    <VIcon class="align-self-center" color="#909399" size="14">info</VIcon>
+                    <VIcon class="align-self-center" color="#909399" size="14"
+                      >info</VIcon
+                    >
                   </el-tooltip>
                   <span>:</span>
                 </template>
                 <ElSwitch v-model="form.ignoreTimePrecision" />
+              </ElFormItem>
+
+              <ElFormItem v-if="!isCountOrHash" class="form-item">
+                <template #label>
+                  <span>{{ $t('packages_business_checkTableThreadNum') }}</span>
+                  <el-tooltip
+                    effect="dark"
+                    placement="top"
+                    :content="$t('packages_business_checkTableThreadNum_tip')"
+                  >
+                    <VIcon class="align-self-center" color="#909399" size="14"
+                      >info</VIcon
+                    >
+                  </el-tooltip>
+                  <span>:</span>
+                </template>
+                <ElInputNumber v-model="form.checkTableThreadNum" :min="1" />
               </ElFormItem>
 
               <template v-if="form.inspectMethod === 'cdcCount'">


### PR DESCRIPTION
- Introduced a new option for specifying the number of threads to use for validation, with a default value of 10.
- Updated English, Simplified Chinese, and Traditional Chinese locale files to include translations for the new feature.
- Added an input field in the verification form to allow users to adjust the thread count based on system resources.