### PR TITLE
feat: enhance time precision settings and localization support

### DIFF
--- a/packages/business/src/locale/lang/en.js
+++ b/packages/business/src/locale/lang/en.js
@@ -1587,7 +1587,7 @@ export default {
     'When the associated fields contain NULL values, the database defaults to sorting NULL values last, which may cause validation failure. Enabling this option will set NULL values first, but may not use the database index, increasing database load.',
   packages_business_ignoreTimePrecision: 'Ignore time precision',
   packages_business_ignoreTimePrecision_tip:
-    'When enabled, time will be compared up to seconds only, ignoring milliseconds. Useful for syncing high-precision and low-precision time fields.',
+    'When enabled, time comparison ignores milliseconds and is accurate to the second. Supports rounding (e.g. ≥500ms becomes 1s) or truncation (milliseconds are removed), useful for syncing high- and low-precision time fields.',
   packages_business_checkTableThreadNum: 'Thread Validation',
   packages_business_checkTableThreadNum_tip:
     'Number of threads to use. Default is 10. Can be increased if system resources permit.',
@@ -1604,4 +1604,6 @@ export default {
   packages_business_available_variables: 'Available Variables',
   packages_business_click_variable_name_insert_template:
     'Click variable name to insert into template',
+  packages_business_ignoreTimePrecision_round: 'Round',
+  packages_business_ignoreTimePrecision_truncate: 'Truncate',
 }

--- a/packages/business/src/locale/lang/zh-CN.js
+++ b/packages/business/src/locale/lang/zh-CN.js
@@ -1414,7 +1414,7 @@ export default {
     '关联字段存在NULL值时，数据库默认将NULL排在最后，可能导致校验失败。开启此选项将NULL值排在前面，但可能无法使用数据库索引，增加数据库负载。',
   packages_business_ignoreTimePrecision: '忽略时间精度',
   packages_business_ignoreTimePrecision_tip:
-    '开启此开关后会忽略时间毫秒级的比较，只精确到秒级，适用于高精度时间字段同步低精度时间字段场景。',
+    '开启此开关后，将忽略时间的毫秒级比较，只精确到秒级。可选“四舍五入”（如 ≥500ms 变为 1s）或“截断”（去除毫秒部分）方式处理，适用于高精度时间字段同步低精度字段的场景。',
   packages_business_checkTableThreadNum: '校验线程数量',
   packages_business_checkTableThreadNum_tip:
     '校验线程数量，在资源充足的情况下可进行调整，默认线程数为 10',
@@ -1429,4 +1429,6 @@ export default {
   packages_business_available_variables: '可用变量',
   packages_business_click_variable_name_insert_template:
     '点击变量名称插入到模板中',
+  packages_business_ignoreTimePrecision_round: '四舍五入',
+  packages_business_ignoreTimePrecision_truncate: '截断',
 }

--- a/packages/business/src/locale/lang/zh-TW.js
+++ b/packages/business/src/locale/lang/zh-TW.js
@@ -1402,6 +1402,8 @@ export default {
   packages_business_nulls_first_tip:
     '關聯字段存在NULL值時，數據庫默認將NULL排在最後，可能導致校驗失敗。開啓此選項將NULL值排在前面，但可能無法使用數據庫索引，增加數據庫負載。',
   packages_business_ignoreTimePrecision: '忽略時間精度',
+  packages_business_ignoreTimePrecision_tip:
+    '開啓此開關後，將忽略時間的毫秒級比較，只精確到秒級。可選擇“四捨五入”（如 ≥500ms 變為 1s）或“截斷”（去除毫秒部分）方式處理，適用於高精度時間字段與低精度時間字段同步的場景。',
   packages_business_checkTableThreadNum: '校驗線程數量',
   packages_business_checkTableThreadNum_tip:
     '校驗線程數量，在資源充足的情況下可進行調整，默認線程數為 10',
@@ -1416,4 +1418,6 @@ export default {
   packages_business_available_variables: '可用變量',
   packages_business_click_variable_name_insert_template:
     '點擊變量名稱插入到模板中',
+  packages_business_ignoreTimePrecision_round: '四捨五入',
+  packages_business_ignoreTimePrecision_truncate: '截斷',
 }

--- a/packages/business/src/views/verification/Form.vue
+++ b/packages/business/src/views/verification/Form.vue
@@ -114,6 +114,7 @@ const form = reactive({
   errorNotifys: ['SYSTEM', 'EMAIL'],
   inconsistentNotifys: ['SYSTEM', 'EMAIL'],
   checkTableThreadNum: 10,
+  roundingMode: 'HALF_UP',
   alarmSettings: [
     {
       type: 'INSPECT',
@@ -627,7 +628,7 @@ provide('ConnectorMap', ConnectorMap)
           required
           class="form-item"
           prop="flowId"
-          :label="`${$t('packages_business_verification_chooseJob')}: `"
+          :label="`${$t('packages_business_verification_chooseJob')}`"
         >
           <InfiniteSelect
             ref="taskSelect"
@@ -647,7 +648,7 @@ provide('ConnectorMap', ConnectorMap)
           required
           class="form-item"
           prop="name"
-          :label="`${$t('packages_business_verification_task_name')}: `"
+          :label="`${$t('packages_business_verification_task_name')}`"
         >
           <ElInput v-model="form.name" class="form-input" />
         </ElFormItem>
@@ -656,7 +657,7 @@ provide('ConnectorMap', ConnectorMap)
       <ElFormItem
         required
         class="form-item"
-        :label="`${$t('packages_business_verification_type')}: `"
+        :label="`${$t('packages_business_verification_type')}`"
       >
         <div>
           <el-radio-group
@@ -715,7 +716,7 @@ provide('ConnectorMap', ConnectorMap)
             v-if="form.inspectMethod !== 'hash'"
             class="form-item"
             prop="inspectDifferenceMode"
-            :label="`${$t('packages_business_verification_form_jieguoshuchu')}: `"
+            :label="`${$t('packages_business_verification_form_jieguoshuchu')}`"
           >
             <ElSelect
               v-model="form.inspectDifferenceMode"
@@ -739,7 +740,7 @@ provide('ConnectorMap', ConnectorMap)
 
           <ElFormItem
             class="form-item"
-            :label="`${$t('packages_business_verification_frequency')}: `"
+            :label="`${$t('packages_business_verification_frequency')}`"
           >
             <ElSelect
               v-model="form.mode"
@@ -759,7 +760,7 @@ provide('ConnectorMap', ConnectorMap)
           <ElFormItem
             v-if="form.mode === 'cron'"
             class="form-item"
-            :label="`${$t('packages_business_verification_is_enabled')}: `"
+            :label="`${$t('packages_business_verification_is_enabled')}`"
           >
             <ElSwitch v-model="form.enabled" />
           </ElFormItem>
@@ -767,7 +768,7 @@ provide('ConnectorMap', ConnectorMap)
             <ElFormItem
               class="form-item"
               prop="timing.start"
-              :label="`${$t('packages_business_verification_startAndStopTime')}: `"
+              :label="`${$t('packages_business_verification_startAndStopTime')}`"
             >
               <ElDatePicker
                 :model-value="[form.timing.start, form.timing.end]"
@@ -783,7 +784,7 @@ provide('ConnectorMap', ConnectorMap)
             <ElFormItem
               class="form-item"
               prop="timing.intervals"
-              :label="`${$t('packages_business_verification_verifyInterval')}: `"
+              :label="`${$t('packages_business_verification_verifyInterval')}`"
             >
               <ElInput
                 v-model="form.timing.intervals"
@@ -810,7 +811,7 @@ provide('ConnectorMap', ConnectorMap)
 
           <ElFormItem
             class="form-item"
-            :label="`${$t('packages_business_verification_form_task_alarm')}: `"
+            :label="`${$t('packages_business_verification_form_task_alarm')}`"
           >
             <div class="inline-block">
               <div>
@@ -932,9 +933,7 @@ provide('ConnectorMap', ConnectorMap)
           <ElFormItem
             v-if="form.inspectMethod !== 'hash'"
             class="form-item"
-            :label="`${$t(
-              'packages_business_verification_form_label_error_save_count',
-            )}: `"
+            :label="`${$t('packages_business_verification_form_label_error_save_count')}`"
           >
             <ElSelect v-model="form.limit.keep" class="form-select">
               <ElOption :value="100" label="100(rows)" />
@@ -945,9 +944,10 @@ provide('ConnectorMap', ConnectorMap)
 
           <ElFormItem v-if="!isCountOrHash" class="form-item">
             <template #label>
-              <span>{{ $t('packages_business_ignoreTimePrecision') }}</span>
+              <span class="align-middle mr-1">{{
+                $t('packages_business_ignoreTimePrecision')
+              }}</span>
               <el-tooltip
-                effect="dark"
                 placement="top"
                 :content="$t('packages_business_ignoreTimePrecision_tip')"
               >
@@ -955,16 +955,30 @@ provide('ConnectorMap', ConnectorMap)
                   >info</VIcon
                 >
               </el-tooltip>
-              <span>:</span>
             </template>
-            <ElSwitch v-model="form.ignoreTimePrecision" />
+            <div class="flex align-center">
+              <ElSwitch v-model="form.ignoreTimePrecision" />
+
+              <template v-if="form.ignoreTimePrecision">
+                <el-divider direction="vertical" class="mx-4" />
+                <el-radio-group v-model="form.roundingMode">
+                  <el-radio value="HALF_UP">
+                    {{ $t('packages_business_ignoreTimePrecision_round') }}
+                  </el-radio>
+                  <el-radio value="DOWN">
+                    {{ $t('packages_business_ignoreTimePrecision_truncate') }}
+                  </el-radio>
+                </el-radio-group>
+              </template>
+            </div>
           </ElFormItem>
 
           <ElFormItem v-if="!isCountOrHash" class="form-item">
             <template #label>
-              <span>{{ $t('packages_business_checkTableThreadNum') }}</span>
+              <span class="align-middle mr-1">{{
+                $t('packages_business_checkTableThreadNum')
+              }}</span>
               <el-tooltip
-                effect="dark"
                 placement="top"
                 :content="$t('packages_business_checkTableThreadNum_tip')"
               >
@@ -972,7 +986,6 @@ provide('ConnectorMap', ConnectorMap)
                   >info</VIcon
                 >
               </el-tooltip>
-              <span>:</span>
             </template>
             <ElInputNumber v-model="form.checkTableThreadNum" :min="1" />
           </ElFormItem>


### PR DESCRIPTION
- Updated the ignore time precision tooltip to clarify rounding and truncation options for better user understanding.
- Added new localization keys for rounding and truncation options in English, Simplified Chinese, and Traditional Chinese.
- Improved the Form.vue component to include a radio group for selecting rounding modes when time precision is ignored.