### PR TITLE
feat: enhance TableSelect component with partitioning support

### DIFF
--- a/packages/dag/src/nodes/Table.js
+++ b/packages/dag/src/nodes/Table.js
@@ -206,6 +206,9 @@ export class Table extends NodeType {
                           connectionId: '{{$values.connectionId}}',
                           itemType: 'string',
                           itemQuery: 'value',
+                          hasPartition: `{{$values.attrs.capabilities.some(item => item.id==="source_support_partition")}}`,
+                          syncPartitionTableEnable:
+                            '{{$values.syncSourcePartitionTableEnable}}',
                         },
                         'x-reactions': [
                           {
@@ -246,6 +249,30 @@ export class Table extends NodeType {
                               'x-component-props.content': '{{$deps[0]}}',
                             },
                           },
+                        },
+                      },
+                    },
+                  },
+
+                  syncSourcePartitionTableEnable: {
+                    title: i18n.t(
+                      'packages_dag_syncSourcePartitionTableEnable',
+                    ),
+                    type: 'boolean',
+                    default: true,
+                    'x-decorator': 'FormItem',
+                    'x-decorator-props': {
+                      class: 'flex-1',
+                      tooltip: i18n.t(
+                        'packages_dag_syncSourcePartitionTableEnable_tip',
+                      ),
+                    },
+                    'x-component': 'Switch',
+                    'x-reactions': {
+                      fulfill: {
+                        state: {
+                          visible:
+                            '{{$values.attrs.capabilities.some(item => item.id==="source_support_partition")}}',
                         },
                       },
                     },


### PR DESCRIPTION
- Added new props 'hasPartition', 'syncPartitionTableEnable', and 'method' to the TableSelect component for improved functionality.
- Implemented caching and filtering logic for partition tables in the fetchMethod.
- Updated the Table node to include new attributes for partition support and synchronization options.