### PR TITLE
feat: add license alert settings and email template functionality

### DIFF
--- a/apps/daas/src/components.d.ts
+++ b/apps/daas/src/components.d.ts
@@ -107,6 +107,7 @@ declare module 'vue' {
     'IMingcute:addLine': typeof import('~icons/mingcute/add-line')['default']
     'IMingcute:arrowRightLine': typeof import('~icons/mingcute/arrow-right-line')['default']
     'IMingcute:checkLine': typeof import('~icons/mingcute/check-line')['default']
+    'IMingcute:closeLine': typeof import('~icons/mingcute/close-line')['default']
     'IMingcute:download2Line': typeof import('~icons/mingcute/download2-line')['default']
     'IMingcute:externalLinkLine': typeof import('~icons/mingcute/external-link-line')['default']
     'IMingcute:loadingLine': typeof import('~icons/mingcute/loading-line')['default']

--- a/apps/daas/src/i18n/langs/en.js
+++ b/apps/daas/src/i18n/langs/en.js
@@ -2134,4 +2134,8 @@ export default {
   account_accessCode_tip:
     'Refreshing the access code will invalidate the current code, and the system will generate a new one.<b class="color-warning">Update the access code in the engine\'s configuration file and restart it to ensure proper functioning. Handle with care.</b>',
   account_accessCode_success: 'Access code refreshed successfully',
+  setting_license_remainingDaysThreshold: 'Remaining Days <=',
+  setting_license_rule: 'License Alert Rule',
+  setting_license_alarm_template: 'Alert Template',
+  setting_license_alarm_template_custom: 'Custom Alert Template',
 }

--- a/apps/daas/src/i18n/langs/zh-CN.js
+++ b/apps/daas/src/i18n/langs/zh-CN.js
@@ -2025,4 +2025,8 @@ export default {
   account_accessCode_tip:
     '刷新访问码将导致当前访问码失效，系统将生成新的访问码。<b class="color-warning">您需要将新的访问码更新到引擎的配置文件后，重新启动引擎，否则引擎可能会无法正常工作。请谨慎操作！</b>',
   account_accessCode_success: '刷新访问码成功',
+  setting_license_remainingDaysThreshold: '剩余天数 <=',
+  setting_license_rule: 'License 告警规则',
+  setting_license_alarm_template: '告警模板',
+  setting_license_alarm_template_custom: '自定义告警模板',
 }

--- a/apps/daas/src/i18n/langs/zh-TW.js
+++ b/apps/daas/src/i18n/langs/zh-TW.js
@@ -2009,4 +2009,8 @@ export default {
   account_accessCode_tip:
     '刷新訪問碼將導致當前訪問碼失效，系統將生成新的訪問碼。<b class="color-warning">您需要將新的訪問碼更新到引擎的配置文件後，重新啓動引擎，否則引擎可能會無法正常工作。請謹慎操作！</b>',
   account_accessCode_success: '刷新訪問碼成功',
+  setting_license_remainingDaysThreshold: '剩余天数 <=',
+  setting_license_rule: 'License 告警規則',
+  setting_license_alarm_template: '告警模板',
+  setting_license_alarm_template_custom: '自定義告警模板',
 }

--- a/packages/assets/styles/utilities.scss
+++ b/packages/assets/styles/utilities.scss
@@ -2669,7 +2669,7 @@
 }
 
 .text-secondary {
-  color: #6c757d !important;
+  color: var(--el-text-color-secondary) !important;
 }
 
 .text-success {

--- a/packages/business/src/views/setting/EmailTemplateDialog.vue
+++ b/packages/business/src/views/setting/EmailTemplateDialog.vue
@@ -24,6 +24,7 @@ import type { ElInput } from 'element-plus'
 
 defineProps<{
   keyMapping: Record<string, string>
+  hideMenu?: boolean
 }>()
 
 const { t } = useI18n()
@@ -262,6 +263,23 @@ const variablesMap = reactive({
       icon: IconLucideHash,
     },
   ],
+  license_alarm_template: [
+    {
+      name: 'level',
+      label: t('packages_dag_components_alert_gaojingjibie'),
+      icon: IconLucideFileText,
+    },
+    {
+      name: 'remainingDays',
+      label: t('public_remaining_days'),
+      icon: IconLucideFileText,
+    },
+    {
+      name: 'remainingDaysThreshold',
+      label: t('public_remaining_days_threshold'),
+      icon: IconLucideFileText,
+    },
+  ],
 })
 
 const availableVariables = computed(() => {
@@ -485,7 +503,7 @@ defineExpose({
     class="mail-template-dialog p-0"
   >
     <div class="border-top border-bottom flex flex-1 min-h-0">
-      <div class="flex flex-column">
+      <div v-if="!hideMenu" class="flex flex-column">
         <el-scrollbar class="bg-light">
           <div class="p-3 pl-4">
             <div class="font-color-light mb-3 px-2">

--- a/packages/i18n/src/locale/lang/en.js
+++ b/packages/i18n/src/locale/lang/en.js
@@ -498,4 +498,7 @@ export default {
   public_time_precision_truncate: 'Truncate',
   public_button_unpublish: 'Unpublish',
   public_system: 'System',
+  public_rule_add: 'Add Rule',
+  public_remaining_days: 'Remaining Days',
+  public_remaining_days_threshold: 'Remaining Days Threshold',
 }

--- a/packages/i18n/src/locale/lang/zh-CN.js
+++ b/packages/i18n/src/locale/lang/zh-CN.js
@@ -489,4 +489,7 @@ export default {
   public_time_precision_truncate: '截断',
   public_button_unpublish: '撤销',
   public_system: '系统',
+  public_rule_add: '添加规则',
+  public_remaining_days: '剩余天数',
+  public_remaining_days_threshold: '剩余天数阈值',
 }

--- a/packages/i18n/src/locale/lang/zh-TW.js
+++ b/packages/i18n/src/locale/lang/zh-TW.js
@@ -488,4 +488,7 @@ export default {
   public_time_precision_truncate: '截斷',
   public_button_unpublish: '撤銷',
   public_system: '系統',
+  public_rule_add: '添加規則',
+  public_remaining_days: '剩余天数',
+  public_remaining_days_threshold: '剩余天数阈值',
 }


### PR DESCRIPTION
- Introduced new translation keys for license alert rules and templates in English, Simplified Chinese, and Traditional Chinese.
- Enhanced the Setting.vue component to manage license alert rules and email templates, including adding and removing rules.
- Integrated EmailTemplateDialog for customizing email alert templates.
- Updated styles for better visual consistency in the application.