### PR TITLE
feat: update translation keys and component structure in SceneDialog …

### DIFF
--- a/packages/business/src/components/create-connection/SceneDialog.vue
+++ b/packages/business/src/components/create-connection/SceneDialog.vue
@@ -433,7 +433,7 @@ export default {
           {
             key: 'apiApp',
             icon: 'mini-app',
-            name: this.$t('packages_business_api_application'),
+            name: this.$t('public_api_group'),
             md: this.$t('packages_business_api_application_md'),
           },
         ],

--- a/packages/business/src/components/create-connection/ServeForm.vue
+++ b/packages/business/src/components/create-connection/ServeForm.vue
@@ -7,7 +7,7 @@ import i18n from '@tap/i18n'
 
 export default {
   name: 'ServeForm',
-  components: { GitBook, SchemaToForm },
+  components: { SchemaToForm },
   directives: {
     resize,
   },
@@ -25,11 +25,26 @@ export default {
       schemaData: null,
       submitBtnLoading: false,
       saveAndMoreLoading: false,
+      isDaas: import.meta.env.VUE_APP_PLATFORM === 'DAAS',
     }
   },
   computed: {
     schemaFormInstance() {
       return this.$refs.schemaToForm.getForm?.()
+    },
+    apiSrc() {
+      let domain
+
+      if (this.isDaas) {
+        domain = this.$i18n.locale === 'en' ? '/docs/en/' : '/docs/'
+      } else {
+        domain =
+          !this.$store.getters.isDomesticStation || this.$i18n.locale === 'en'
+            ? 'https://docs.tapdata.io/'
+            : 'https://docs.tapdata.net/'
+      }
+
+      return `${domain}user-guide/data-service/create-api-service?from=cloud`
     },
   },
   mounted() {
@@ -116,21 +131,14 @@ export default {
         >
       </div>
     </div>
-    <GitBook
-      v-resize.left="{
-        minWidth: 350,
-      }"
-      :value="params.md"
-      class="git-book overflow-auto"
-    />
+    <div class="flex-1 border-start">
+      <iframe :src="apiSrc" class="w-100 h-100 block" />
+    </div>
   </div>
 </template>
 
 <style lang="scss" scoped>
 .footer-operation {
   border-top: 1px solid #e1e3e9;
-}
-.git-book {
-  width: 400px;
 }
 </style>

--- a/packages/business/src/views/data-server/List.vue
+++ b/packages/business/src/views/data-server/List.vue
@@ -549,7 +549,7 @@ defineExpose({
             </template>
           </el-button>
           <div class="fs-6 flex-1">
-            <span>{{ $t('public_application') }}</span>
+            <span>{{ $t('public_api_group') }}</span>
           </div>
           <el-button
             text

--- a/packages/i18n/src/locale/lang/en.js
+++ b/packages/i18n/src/locale/lang/en.js
@@ -501,4 +501,5 @@ export default {
   public_rule_add: 'Add Rule',
   public_remaining_days: 'Remaining Days',
   public_remaining_days_threshold: 'Remaining Days Threshold',
+  public_api_group: 'API Group',
 }

--- a/packages/i18n/src/locale/lang/zh-CN.js
+++ b/packages/i18n/src/locale/lang/zh-CN.js
@@ -492,4 +492,5 @@ export default {
   public_rule_add: '添加规则',
   public_remaining_days: '剩余天数',
   public_remaining_days_threshold: '剩余天数阈值',
+  public_api_group: 'API 分组',
 }

--- a/packages/i18n/src/locale/lang/zh-TW.js
+++ b/packages/i18n/src/locale/lang/zh-TW.js
@@ -491,4 +491,5 @@ export default {
   public_rule_add: '添加規則',
   public_remaining_days: '剩余天数',
   public_remaining_days_threshold: '剩余天数阈值',
+  public_api_group: 'API 分組',
 }


### PR DESCRIPTION
…and ServeForm

- Changed the translation key from 'packages_business_api_application' to 'public_api_group' in SceneDialog.vue and List.vue.
- Removed GitBook component from ServeForm.vue and replaced it with an iframe to display API documentation based on the platform.
- Added a computed property to dynamically generate the API source URL in ServeForm.vue.
- Updated localization files to include the new 'public_api_group' key in English, Simplified Chinese, and Traditional Chinese.