### PR TITLE
fix(TAP-11725): [to 4.15] When modifying the connection of an API, if the conne…

### DIFF
--- a/packages/business/src/views/data-server/Drawer.vue
+++ b/packages/business/src/views/data-server/Drawer.vue
@@ -464,6 +464,7 @@ const save = async (type?: boolean) => {
         readPreference: '',
         readPreferenceTag: '',
         limit,
+        connection: connectionId,
         datasource: connectionId,
         tablename: tableName,
         apiVersion,


### PR DESCRIPTION
…ction field is not updated, the API will not be able to find the corresponding connection information, resulting in API publishing failure