### PR TITLE
feat(group-export): 本地导出加「移除敏感信息」勾选，默认保真

### DIFF
--- a/apps/daas/src/i18n/langs/en.js
+++ b/apps/daas/src/i18n/langs/en.js
@@ -133,6 +133,13 @@ export default {
   data_import_export_transfer_type: 'Export Type',
   data_import_export_file_export: 'File Export',
   data_import_export_git_export: 'Git Export',
+  data_import_export_remove_sensitive_data: 'Remove sensitive data',
+  data_import_export_remove_sensitive_data_on_tip:
+    'The package carries no connection credentials. On import, credentials already configured in the target environment are kept instead of being cleared.',
+  data_import_export_remove_sensitive_data_off_tip:
+    'The package will contain plaintext database credentials (host, username, password). Do not share it or commit it to a code repository.',
+  data_import_export_git_always_masked_tip:
+    'Git export always removes connection credentials and cannot be turned off — repository history cannot be taken back.',
   data_import_export_git_config_required:
     'Git configuration is required for this project',
   data_import_export_config_git: 'Configure Git',

--- a/apps/daas/src/i18n/langs/zh-CN.js
+++ b/apps/daas/src/i18n/langs/zh-CN.js
@@ -130,6 +130,13 @@ export default {
   data_import_export_transfer_type: '导出类型',
   data_import_export_file_export: '文件导出',
   data_import_export_git_export: 'Git 导出',
+  data_import_export_remove_sensitive_data: '移除敏感信息',
+  data_import_export_remove_sensitive_data_on_tip:
+    '包内不含连接凭据。导入时目标环境已配置的凭据将被保留，不会被清空。',
+  data_import_export_remove_sensitive_data_off_tip:
+    '导出包内将含数据库连接的明文凭据（地址、账号、密码），请勿外发或提交到代码仓库。',
+  data_import_export_git_always_masked_tip:
+    'Git 导出一律移除连接凭据，不可关闭 —— 提交进仓库的历史无法撤回。',
   data_import_export_git_config_required: '该项目尚未配置 Git 信息',
   data_import_export_config_git: '配置 Git',
   data_import_export_latest_tag: '最新 Tag',

--- a/apps/daas/src/i18n/langs/zh-TW.js
+++ b/apps/daas/src/i18n/langs/zh-TW.js
@@ -130,6 +130,13 @@ export default {
   data_import_export_transfer_type: '導出類型',
   data_import_export_file_export: '文件導出',
   data_import_export_git_export: 'Git 導出',
+  data_import_export_remove_sensitive_data: '移除敏感信息',
+  data_import_export_remove_sensitive_data_on_tip:
+    '包內不含連接憑據。導入時目標環境已配置的憑據將被保留，不會被清空。',
+  data_import_export_remove_sensitive_data_off_tip:
+    '導出包內將含數據庫連接的明文憑據（地址、賬號、密碼），請勿外發或提交到代碼倉庫。',
+  data_import_export_git_always_masked_tip:
+    'Git 導出一律移除連接憑據，不可關閉 —— 提交進倉庫的歷史無法撤回。',
   data_import_export_git_config_required: '該項目尚未配置 Git 信息',
   data_import_export_config_git: '配置 Git',
   data_import_export_latest_tag: '最新 Tag',

--- a/apps/daas/src/views/data-import-export/GroupExportDialog.vue
+++ b/apps/daas/src/views/data-import-export/GroupExportDialog.vue
@@ -34,6 +34,9 @@ const searchKeyword = ref('') // 搜索关键词
 // 导出状态
 const exporting = ref(false)
 const groupTransferType = ref<'FILE' | 'GIT'>('FILE') // 导出类型
+// 是否移除包内敏感信息（连接凭据）。默认 false = 保真，本地导出的包能直接搬到另一个环境用。
+// 仅对 FILE 生效：GIT 由后端强制脱敏，界面不给这个假开关。
+const removeSensitiveData = ref(false)
 const gitBranchName = ref('') // 分支名
 const gitPrTitle = ref('') // PR 标题
 const gitPrDescription = ref('') // PR 描述
@@ -180,6 +183,7 @@ watch(visible, async (val) => {
 
     // 重置导出类型和字段
     groupTransferType.value = 'FILE'
+    removeSensitiveData.value = false
     gitBranchName.value = generateBranchName()
     gitPrTitle.value = ''
     gitPrDescription.value = ''
@@ -280,11 +284,13 @@ const handleExport = async () => {
       const res = await exportGroupInfoBatch({
         groupIds: selectedGroupIds.value,
         groupTransferType: groupTransferType.value,
+        removeSensitiveData: removeSensitiveData.value,
         groupResetTask: rerunData,
       })
       downloadBlob(res)
     } else {
-      // 调用导出接口
+      // 调用导出接口。GIT 不带 removeSensitiveData：后端强制脱敏，
+      // 显式发 false 只会换回一条「你的请求被覆盖了」的告警，而界面从未给过这个选择。
       await exportGroupInfoBatchGit({
         groupIds: selectedGroupIds.value,
         groupTransferType: groupTransferType.value,
@@ -458,6 +464,32 @@ const handleCreateProject = () => {
                 </div>
               </el-radio>
             </el-radio-group>
+
+            <!-- 敏感信息：FILE 可选（默认保真），GIT 后端强制脱敏、只说明不给假开关 -->
+            <div class="mt-2">
+              <template v-if="groupTransferType === 'FILE'">
+                <el-checkbox v-model="removeSensitiveData" class="h-auto">
+                  {{ $t('data_import_export_remove_sensitive_data') }}
+                </el-checkbox>
+                <div
+                  v-if="removeSensitiveData"
+                  class="fs-8 font-color-sslight lh-base"
+                >
+                  {{ $t('data_import_export_remove_sensitive_data_on_tip') }}
+                </div>
+                <div v-else class="fs-8 color-warning lh-base flex gap-1">
+                  <el-icon class="flex-shrink-0 mt-1">
+                    <i-lucide-triangle-alert />
+                  </el-icon>
+                  <span>{{
+                    $t('data_import_export_remove_sensitive_data_off_tip')
+                  }}</span>
+                </div>
+              </template>
+              <div v-else class="fs-8 font-color-sslight lh-base">
+                {{ $t('data_import_export_git_always_masked_tip') }}
+              </div>
+            </div>
 
             <!-- Git 配置入口 -->
             <div v-if="needGitConfig" class="mt-2">

--- a/packages/api/src/core/group-info.ts
+++ b/packages/api/src/core/group-info.ts
@@ -126,6 +126,14 @@ export function deleteGroupInfo(id: string) {
 export interface ExportGroupInfoBatchParams {
   groupIds: string[]
   groupTransferType: 'FILE' | 'GIT'
+  /**
+   * 是否移除包内的敏感信息（连接凭据）。三态语义与后端 ExportGroupRequest 对齐：
+   * 省略 = 未指定（FILE 按保真、GIT 按脱敏）、true = 要求脱敏、false = 要求保真。
+   *
+   * GIT 路径后端强制脱敏、本字段一律不生效，所以 GIT 导出**不要发送它**：
+   * 发 false 会被后端当成「用户明确要保真却被覆盖」而回告一条告警，而界面上从未给过这个选择。
+   */
+  removeSensitiveData?: boolean
   groupResetTask: {
     [groupId: string]: string[]
   }


### PR DESCRIPTION
## 背景

后端把分组导出的 secret 处理从「一刀切脱敏」改成按用途分流（配套 PR：tapdata/tapdata#3413）：

- **本地导出（FILE）默认保真**，可选移除敏感信息；
- **GitHub 导出（GIT）强制脱敏**，不可被入参绕过。

本地包从此默认**含明文凭据**，误传/误共享的后果更重 —— 所以这件事必须在导出弹窗上看得见。

## 改了什么

- `ExportGroupInfoBatchParams` 加 `removeSensitiveData?`（三态语义与后端 `ExportGroupRequest` 对齐：不传 = 按用途取默认）。
- `GroupExportDialog.vue`：勾选框**仅 FILE 分支渲染**、**默认不勾**（＝保真）；未勾选时用**告警色 + 图标**显形「包内将含明文凭据」。
- **GIT 分支只给一句说明、不给假开关**，并且**刻意不发该字段** —— 后端对 GIT 强制脱敏，前端发 `false` 只会换回一条「你的请求被覆盖了」的告警，而界面从未给过这个选择；那条回告是给显式调 API 的人用的。
- i18n `en` / `zh-CN` / `zh-TW` 各 4 个 key。

## 验证

本仓无测试框架（无 vitest / jest / test-utils），故用三道闸：

- **类型**：`vue-tsc` 新增行零报错（仓库基线本就有 5156 条 `error TS`，根 `type-check` 脚本自身是坏的）。**并做了变异**：把接口字段改名 → `GroupExportDialog.vue(287,9) TS2561` 精确打红 FILE 调用点，证明这道闸有牙。
- **lint**：五个文件与 HEAD 基线**逐字相同**（17 problems 全在既有代码）。
- **i18n**：4 个 key 在三语真实 import 下全部 resolve。
- **API 层行为**已随后端实机验过（FILE 保真 / 勾选后脱敏 / GIT 强制脱敏）。

**未做**：勾选框的浏览器肉眼确认（长什么样、GIT 下是否真的隐藏）—— 需要 review 时顺手看一眼。